### PR TITLE
fix possible connection leak

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/connectors/redshift/RedshiftManifestEmitter.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/redshift/RedshiftManifestEmitter.java
@@ -130,6 +130,7 @@ public class RedshiftManifestEmitter implements IEmitter<String> {
                 writeManifestToS3(manifestFileName, deduplicatedRecords);
             } catch (Exception e) {
                 LOG.error("Error writing file " + manifestFileName + " to S3. Failing this emit attempt.", e);
+                rollbackAndCloseConnection(conn);
                 return buffer.getRecords();
             }
 


### PR DESCRIPTION
Besides the fix, I have a question. When multiple redshift emitters are running concurrently, is it possible for a file to be loaded twice?

The current workflow is:

```
start transaction
check for already loaded files
write and upload manifest containing not loaded files
insert not loaded files
copy manifest
commit
```

<hr>

What if two emitters are both trying to load the same file. 

```
emitter 1  -----------------------------------------------  emitter 2

start transaction
check for already loaded files
                                                          start transaction
                                                          check for already loaded files
                    (both consider the file not loaded)
upload manifest
insert file as loaded
                                                          upload manifest
                                                          insert file as loaded
                    (both insert successfully)
copy manifest
commit
                                                          copy manifest
                                                          commit
                    (the file is being copied twice)
```
